### PR TITLE
Simplify Scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "./node_modules/.bin/webpack",
-    "build:prod": "./node_modules/.bin/webpack -p",
-    "watch": "./node_modules/.bin/webpack --watch",
-    "dev": "./node_modules/.bin/webpack-dev-server"
+    "build": "webpack",
+    "build:prod": "webpack -p",
+    "watch": "webpack --watch",
+    "dev": "webpack-dev-server"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
scripts default to the `.bin` folder in `node_modules` *before* global installs. You can test this by:

```
npm uninstall -g webpack
npm run build
# Reinstall here if you want.
```

This is important because it means one less binary installed on your PATH. (YAY!)